### PR TITLE
remove mixed transforms to enable MKL

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -2,9 +2,9 @@
 
 [[AbstractFFTs]]
 deps = ["LinearAlgebra"]
-git-tree-sha1 = "380e36c66edfa099cd90116b24c1ce8cafccac40"
+git-tree-sha1 = "051c95d6836228d120f5f4b984dd5aba1624f716"
 uuid = "621f4979-c628-5d54-868e-fcf4e3e8185c"
-version = "0.4.1"
+version = "0.5.0"
 
 [[Adapt]]
 deps = ["LinearAlgebra"]
@@ -20,60 +20,42 @@ version = "0.0.4"
 
 [[ArrayInterface]]
 deps = ["LinearAlgebra", "Requires", "SparseArrays"]
-git-tree-sha1 = "981354dab938901c2b607a213e62d9defa50b698"
+git-tree-sha1 = "954b48dedb37ce8211209533380352c28e023fc4"
 uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
-version = "1.2.1"
+version = "2.1.0"
+
+[[ArrayLayouts]]
+deps = ["FillArrays", "LinearAlgebra"]
+git-tree-sha1 = "bc779df8d73be70e4e05a63727d3a4dfb4c52b1f"
+uuid = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
+version = "0.1.5"
 
 [[BandedMatrices]]
-deps = ["FillArrays", "LazyArrays", "LinearAlgebra", "MatrixFactorizations", "Random", "SparseArrays"]
-git-tree-sha1 = "1fd0676c958fe070c0edbffe3197edfdfcced523"
+deps = ["ArrayLayouts", "FillArrays", "LinearAlgebra", "Random", "SparseArrays"]
+git-tree-sha1 = "db5b98c8ea6ee6dc01cad55a79d5277bddfc3c66"
 uuid = "aae01518-5342-5314-be14-df237901396f"
-version = "0.12.0"
+version = "0.14.2"
 
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
-[[BinDeps]]
-deps = ["Compat", "Libdl", "SHA", "URIParser"]
-git-tree-sha1 = "12093ca6cdd0ee547c39b1870e0c9c3f154d9ca9"
-uuid = "9e28174c-4ba2-5203-b857-d8d62c4213ee"
-version = "0.8.10"
-
 [[BinaryProvider]]
-deps = ["Libdl", "Logging", "SHA"]
-git-tree-sha1 = "c7361ce8a2129f20b0e05a89f7070820cfed6648"
+deps = ["Libdl", "SHA"]
+git-tree-sha1 = "5b08ed6036d9d3f0ee6369410b830f8873d4024c"
 uuid = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
-version = "0.5.6"
-
-[[BlockArrays]]
-deps = ["LinearAlgebra"]
-git-tree-sha1 = "87b72cb71d7306b767d175ece832bf8a7f3b6dc8"
-uuid = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
-version = "0.10.0"
-
-[[BlockBandedMatrices]]
-deps = ["BandedMatrices", "BlockArrays", "Distributed", "FillArrays", "LazyArrays", "LinearAlgebra", "MatrixFactorizations", "Pkg", "Profile", "Random", "SharedArrays", "SparseArrays", "Statistics", "Test"]
-git-tree-sha1 = "160fc541f01304ab823d1aff1959e84f28a63faf"
-uuid = "ffab5731-97b5-5995-9138-79e8c1846df0"
-version = "0.5.1"
+version = "0.5.8"
 
 [[BoundaryValueDiffEq]]
 deps = ["BandedMatrices", "DiffEqBase", "DiffEqDiffTools", "ForwardDiff", "LinearAlgebra", "NLsolve", "Reexport", "SparseArrays"]
-git-tree-sha1 = "a8f90377cbed43aa583c19471d34d9653853c52d"
+git-tree-sha1 = "0823edb54c0767701c9e4d3fad3ec4bf0678b083"
 uuid = "764a87c0-6b3e-53db-9096-fe964310641d"
-version = "2.3.0"
-
-[[CSTParser]]
-deps = ["Tokenize"]
-git-tree-sha1 = "c69698c3d4a7255bc1b4bc2afc09f59db910243b"
-uuid = "00ebfdb7-1f24-5e51-bd34-a7502290713f"
-version = "0.6.2"
+version = "2.3.1"
 
 [[Calculus]]
-deps = ["Compat"]
-git-tree-sha1 = "bd8bbd105ba583a42385bd6dc4a20dad8ab3dc11"
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "f641eb0a4f00c343bbc32346e1217b86f3ce9dad"
 uuid = "49dc2e85-a5d0-5ad3-a950-438e2897f1b9"
-version = "0.5.0"
+version = "0.5.1"
 
 [[CodecZlib]]
 deps = ["BinaryProvider", "Libdl", "TranscodingStreams"]
@@ -82,10 +64,10 @@ uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
 version = "0.6.0"
 
 [[ColorSchemes]]
-deps = ["Colors", "Random", "Test"]
-git-tree-sha1 = "cec817e8be9e896266fee4976447c5ced7dc7255"
+deps = ["ColorTypes", "Colors", "FixedPointNumbers", "Random", "Test"]
+git-tree-sha1 = "f876ee572cea8d066b3dd5b903efacdea4072f6b"
 uuid = "35d6a980-a343-548e-a6ea-1d62b119f2f4"
-version = "3.4.0"
+version = "3.5.0"
 
 [[ColorTypes]]
 deps = ["FixedPointNumbers", "Random"]
@@ -107,15 +89,9 @@ version = "0.2.0"
 
 [[Compat]]
 deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
-git-tree-sha1 = "84aa74986c5b9b898b0d1acaf3258741ee64754f"
+git-tree-sha1 = "ed2c4abadf84c53d9e58510b5fc48912c2336fbb"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "2.1.0"
-
-[[Conda]]
-deps = ["JSON", "VersionParsing"]
-git-tree-sha1 = "9a11d428dcdc425072af4aea19ab1e8c3e01c032"
-uuid = "8f4d0f93-b110-5947-807f-2305c1781a2d"
-version = "1.3.0"
+version = "2.2.0"
 
 [[Contour]]
 deps = ["LinearAlgebra", "StaticArrays", "Test"]
@@ -124,15 +100,15 @@ uuid = "d38c429a-6771-53c6-b99e-75d170b6e991"
 version = "0.5.1"
 
 [[DataAPI]]
-git-tree-sha1 = "8903f0219d3472543fc4b2f5ebaf675a07f817c0"
+git-tree-sha1 = "674b67f344687a88310213ddfa8a2b3c76cc4252"
 uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
-version = "1.0.1"
+version = "1.1.0"
 
 [[DataStructures]]
 deps = ["InteractiveUtils", "OrderedCollections"]
-git-tree-sha1 = "0809951a1774dc724da22d26e4289bbaab77809a"
+git-tree-sha1 = "a1b652fb77ae8ca7ea328fa7ba5aa151036e5c10"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.17.0"
+version = "0.17.6"
 
 [[Dates]]
 deps = ["Printf"]
@@ -140,31 +116,31 @@ uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
 
 [[DelayDiffEq]]
 deps = ["DataStructures", "DiffEqBase", "LinearAlgebra", "Logging", "OrdinaryDiffEq", "Parameters", "Printf", "RecursiveArrayTools", "Reexport", "Roots"]
-git-tree-sha1 = "540fa7eb55057ffd8b6687584d2ab273aae4d189"
+git-tree-sha1 = "afa98d9b36df419dbf9586e8f3aa0bf1f4f7cf1d"
 uuid = "bcd4f6db-9728-5f36-b5f7-82caef46ccdb"
-version = "5.16.0"
+version = "5.18.0"
 
 [[DelimitedFiles]]
 deps = ["Mmap"]
 uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 
 [[DiffEqBase]]
-deps = ["ArrayInterface", "Compat", "DiffEqDiffTools", "Distributed", "DocStringExtensions", "FunctionWrappers", "IterativeSolvers", "IteratorInterfaceExtensions", "LinearAlgebra", "MuladdMacro", "Parameters", "Printf", "RecipesBase", "RecursiveArrayTools", "RecursiveFactorization", "Requires", "Roots", "SparseArrays", "StaticArrays", "Statistics", "SuiteSparse", "TableTraits", "TreeViews"]
-git-tree-sha1 = "5629889ad8aae3420cdd59c336ee776404b62c19"
+deps = ["ArrayInterface", "Compat", "DataStructures", "DiffEqDiffTools", "Distributed", "DocStringExtensions", "FunctionWrappers", "IterativeSolvers", "IteratorInterfaceExtensions", "LinearAlgebra", "MuladdMacro", "Parameters", "Printf", "RecipesBase", "RecursiveArrayTools", "RecursiveFactorization", "Requires", "Roots", "SparseArrays", "StaticArrays", "Statistics", "SuiteSparse", "TableTraits", "TreeViews", "ZygoteRules"]
+git-tree-sha1 = "d30016d27988818c30c89e1cc87c7c900fc997fe"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
-version = "6.3.3"
+version = "6.9.1"
 
 [[DiffEqCallbacks]]
-deps = ["DataStructures", "DiffEqBase", "ForwardDiff", "NLsolve", "OrdinaryDiffEq", "RecipesBase", "RecursiveArrayTools", "StaticArrays"]
-git-tree-sha1 = "307eda7b109cf1f236fbbb19976562146af386e1"
+deps = ["DataStructures", "DiffEqBase", "ForwardDiff", "LinearAlgebra", "NLsolve", "OrdinaryDiffEq", "RecipesBase", "RecursiveArrayTools", "StaticArrays"]
+git-tree-sha1 = "f85da2bade6eb9bee58f06540a8c00d071e9f432"
 uuid = "459566f4-90b8-5000-8ac3-15dfb0a30def"
-version = "2.8.0"
+version = "2.10.0"
 
 [[DiffEqDiffTools]]
 deps = ["ArrayInterface", "LinearAlgebra", "Requires", "SparseArrays", "StaticArrays"]
-git-tree-sha1 = "21b855cb29ec4594f9651e0e9bdc0cdcfdcd52c1"
+git-tree-sha1 = "951600cc05d9626c3282e2ed125492931596e430"
 uuid = "01453d9d-ee7c-5054-8395-0335cb756afa"
-version = "1.3.0"
+version = "1.6.0"
 
 [[DiffEqFinancial]]
 deps = ["DiffEqBase", "DiffEqNoiseProcess", "LinearAlgebra", "Markdown", "RandomNumbers"]
@@ -173,22 +149,22 @@ uuid = "5a0ffddc-d203-54b0-88ba-2c03c0fc2e67"
 version = "2.2.1"
 
 [[DiffEqJump]]
-deps = ["Compat", "DataStructures", "DiffEqBase", "FunctionWrappers", "LinearAlgebra", "Parameters", "PoissonRandom", "Random", "RandomNumbers", "RecursiveArrayTools", "TreeViews"]
-git-tree-sha1 = "0fc9a211856cabd0f08a83948f144469fcb4ec92"
+deps = ["Compat", "DataStructures", "DiffEqBase", "FunctionWrappers", "LinearAlgebra", "Parameters", "PoissonRandom", "Random", "RandomNumbers", "RecursiveArrayTools", "Statistics", "TreeViews"]
+git-tree-sha1 = "b76e5511c2b6675445abb3b35892c18ade9abf74"
 uuid = "c894b116-72e5-5b58-be3c-e6d8d4ac2b12"
-version = "6.2.2"
+version = "6.4.0"
 
 [[DiffEqNoiseProcess]]
 deps = ["DataStructures", "DiffEqBase", "LinearAlgebra", "Random", "RandomNumbers", "RecipesBase", "RecursiveArrayTools", "Requires", "ResettableStacks", "StaticArrays", "Statistics"]
-git-tree-sha1 = "f5333c0aa6208680e48cd24ae6f759c262a1cf85"
+git-tree-sha1 = "0641d5d6a1dda2a871698155a50c567526974040"
 uuid = "77a26b50-5914-5dd7-bc55-306e6241c503"
-version = "3.3.1"
+version = "3.7.0"
 
 [[DiffEqPhysics]]
 deps = ["DiffEqBase", "DiffEqCallbacks", "ForwardDiff", "LinearAlgebra", "Printf", "Random", "RecipesBase", "RecursiveArrayTools", "Reexport", "StaticArrays"]
-git-tree-sha1 = "9f4b98590c63bf202d12ae20783203baad3dd27a"
+git-tree-sha1 = "3d7f15f2805bc2f95cfb06d10a920746d11c76d7"
 uuid = "055956cb-9e8b-5191-98cc-73ae4a59e68a"
-version = "3.2.0"
+version = "3.3.0"
 
 [[DiffResults]]
 deps = ["Compat", "StaticArrays"]
@@ -197,22 +173,22 @@ uuid = "163ba53b-c6d8-5494-b064-1a9d43ac40c5"
 version = "0.0.4"
 
 [[DiffRules]]
-deps = ["Random", "Test"]
-git-tree-sha1 = "dc0869fb2f5b23466b32ea799bd82c76480167f7"
+deps = ["NaNMath", "Random", "SpecialFunctions"]
+git-tree-sha1 = "f734b5f6bc9c909027ef99f6d91d5d9e4b111eed"
 uuid = "b552c78f-8df3-52c6-915a-8e097449b14b"
-version = "0.0.10"
+version = "0.1.0"
 
 [[DifferentialEquations]]
 deps = ["BoundaryValueDiffEq", "DelayDiffEq", "DiffEqBase", "DiffEqCallbacks", "DiffEqFinancial", "DiffEqJump", "DiffEqNoiseProcess", "DiffEqPhysics", "DimensionalPlotRecipes", "LinearAlgebra", "MultiScaleArrays", "OrdinaryDiffEq", "Random", "RecursiveArrayTools", "Reexport", "SteadyStateDiffEq", "StochasticDiffEq", "Sundials"]
-git-tree-sha1 = "424f37d9f5ac4719e0dcdfdda0394c37df66f4e4"
+git-tree-sha1 = "92601837d2e6db72a72ff1c2be0ff18c341f8b67"
 uuid = "0c46a032-eb83-5123-abaf-570d42b7fbaa"
-version = "6.8.0"
+version = "6.9.0"
 
 [[DimensionalPlotRecipes]]
-deps = ["LinearAlgebra", "RecipesBase", "Test"]
-git-tree-sha1 = "d348688f9a3d02c24455327231c450c272b7401c"
+deps = ["LinearAlgebra", "RecipesBase"]
+git-tree-sha1 = "051345e6f9a141dc80da32dd9811c538e70a9498"
 uuid = "c619ae07-58cd-5f6d-b883-8f17bd6a98f9"
-version = "0.2.0"
+version = "1.0.0"
 
 [[Distances]]
 deps = ["LinearAlgebra", "Statistics"]
@@ -226,39 +202,47 @@ uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [[DocStringExtensions]]
 deps = ["LibGit2", "Markdown", "Pkg", "Test"]
-git-tree-sha1 = "0513f1a8991e9d83255e0140aace0d0fc4486600"
+git-tree-sha1 = "88bb0edb352b16608036faadcc071adda068582a"
 uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
-version = "0.8.0"
+version = "0.8.1"
 
 [[ExponentialUtilities]]
 deps = ["LinearAlgebra", "Printf", "SparseArrays"]
-git-tree-sha1 = "85e1ce16aa9b98793df704e17e7a0ceadefe404f"
+git-tree-sha1 = "1672dedeacaab85345fd359ad56dde8fb5d48a45"
 uuid = "d4d017d3-3776-5f7e-afef-a10c40355c18"
-version = "1.5.1"
+version = "1.6.0"
 
 [[FFMPEG]]
 deps = ["BinaryProvider", "Libdl"]
-git-tree-sha1 = "f65cf703281fb7917beca5ead1c67e6d60ef9597"
+git-tree-sha1 = "9143266ba77d3313a4cf61d8333a1970e8c5d8b6"
 uuid = "c87230d0-a227-11e9-1b43-d7ebe4e7570a"
-version = "0.2.3"
+version = "0.2.4"
 
 [[FFTW]]
-deps = ["AbstractFFTs", "BinaryProvider", "Conda", "Libdl", "LinearAlgebra", "Reexport", "Test"]
-git-tree-sha1 = "6c5b420da0b8c12098048561b8d58f81adea506f"
+deps = ["AbstractFFTs", "FFTW_jll", "IntelOpenMP_jll", "Libdl", "LinearAlgebra", "MKL_jll", "Reexport"]
+git-tree-sha1 = "dfdd42909270791fc9d0631777d006f405c94d70"
+repo-rev = "master"
+repo-url = "https://github.com/JuliaMath/FFTW.jl.git"
 uuid = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
-version = "1.0.1"
+version = "1.1.0"
+
+[[FFTW_jll]]
+deps = ["Libdl", "Pkg"]
+git-tree-sha1 = "05674f209a6e3387dd103a945b0113eeb64b1a58"
+uuid = "f5851436-0d7a-5f13-b9de-f02708fd171a"
+version = "3.3.9+3"
 
 [[FileIO]]
 deps = ["Pkg"]
-git-tree-sha1 = "351f001a78aa1b7ad2696e386e110b5abd071c71"
+git-tree-sha1 = "80c17c711c41416eb0ac68347dc036be68b37682"
 uuid = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
-version = "1.0.7"
+version = "1.2.0"
 
 [[FillArrays]]
 deps = ["LinearAlgebra", "Random", "SparseArrays"]
-git-tree-sha1 = "bc45e8feb90728a35194f844ef6aadc688e31881"
+git-tree-sha1 = "1a9fe4e1323f38de0ba4da49eafd15b25ec62298"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "0.7.1"
+version = "0.8.2"
 
 [[FixedPointNumbers]]
 git-tree-sha1 = "d14a6fa5890ea3a7e5dcab6811114f132fec2b4b"
@@ -266,10 +250,10 @@ uuid = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 version = "0.6.1"
 
 [[ForwardDiff]]
-deps = ["CommonSubexpressions", "DiffResults", "DiffRules", "InteractiveUtils", "LinearAlgebra", "NaNMath", "Random", "SparseArrays", "SpecialFunctions", "StaticArrays", "Test"]
-git-tree-sha1 = "4c4d727f1b7e0092134fabfab6396b8945c1ea5b"
+deps = ["CommonSubexpressions", "DiffResults", "DiffRules", "NaNMath", "Random", "SpecialFunctions", "StaticArrays"]
+git-tree-sha1 = "da46ac97b17793eba44ff366dc6cb70f1238a738"
 uuid = "f6369f11-7733-5829-9624-2563aa707210"
-version = "0.10.3"
+version = "0.10.7"
 
 [[FunctionWrappers]]
 deps = ["Compat"]
@@ -278,10 +262,10 @@ uuid = "069b7b12-0de2-55c6-9aab-29f3d0a68a2e"
 version = "1.0.0"
 
 [[GR]]
-deps = ["Base64", "DelimitedFiles", "LinearAlgebra", "Pkg", "Printf", "Random", "Serialization", "Sockets", "Test"]
-git-tree-sha1 = "b4c31b6377b6d51b6c69a3a9737d10c34d43974e"
+deps = ["Base64", "DelimitedFiles", "LinearAlgebra", "Printf", "Random", "Serialization", "Sockets", "Test"]
+git-tree-sha1 = "c690c2ab22ac9ee323d9966deae61a089362b25c"
 uuid = "28b8d3ca-fb5f-59d9-8090-bfdbd6d07a71"
-version = "0.41.0"
+version = "0.44.0"
 
 [[GenericSVD]]
 deps = ["LinearAlgebra"]
@@ -301,14 +285,20 @@ git-tree-sha1 = "b7ec91c153cf8bff9aff58b39497925d133ef7fd"
 uuid = "d25df0c9-e2be-5dd7-82c8-3ad0b3e990b9"
 version = "0.1.1"
 
+[[IntelOpenMP_jll]]
+deps = ["Libdl", "Pkg"]
+git-tree-sha1 = "fb8e1c7a5594ba56f9011310790e03b5384998d6"
+uuid = "1d5cc7b8-4909-519e-a0f8-d0f5ad9712d0"
+version = "2018.0.3+0"
+
 [[InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[IterTools]]
-git-tree-sha1 = "2ebe60d7343962966d1779a74a760f13217a6901"
+git-tree-sha1 = "05110a2ab1fc5f932622ffea2a003221f4782c18"
 uuid = "c8e1da08-722c-5040-9ed9-7db0dc04731e"
-version = "1.2.0"
+version = "1.3.0"
 
 [[IterativeSolvers]]
 deps = ["LinearAlgebra", "Printf", "Random", "RecipesBase", "SparseArrays", "Test"]
@@ -322,10 +312,10 @@ uuid = "82899510-4779-5014-852e-03e436cf321d"
 version = "1.0.0"
 
 [[JLD2]]
-deps = ["CodecZlib", "DataStructures", "FileIO", "Mmap", "Printf"]
-git-tree-sha1 = "343d1ec8ae7d57a608d79ef12e9a853cbb9acd96"
+deps = ["CodecZlib", "DataStructures", "FileIO", "Mmap", "Pkg", "Printf", "UUIDs"]
+git-tree-sha1 = "0193ef8c75ce70584198b95b4a48f9ec0c49ffa8"
 uuid = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
-version = "0.1.3"
+version = "0.1.9"
 
 [[JSON]]
 deps = ["Dates", "Mmap", "Parsers", "Unicode"]
@@ -340,10 +330,10 @@ uuid = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
 version = "1.0.3"
 
 [[LazyArrays]]
-deps = ["FillArrays", "LinearAlgebra", "MacroTools", "StaticArrays"]
-git-tree-sha1 = "fbbf7e52929f74ed4f4d2fff4419f76807a443ef"
+deps = ["ArrayLayouts", "FillArrays", "LinearAlgebra", "MacroTools", "StaticArrays"]
+git-tree-sha1 = "f787fc888b28b83ae32863f2ae54f47e8ca40eaf"
 uuid = "5078a376-72f3-5289-bfd5-ec5146d43c02"
-version = "0.12.0"
+version = "0.14.10"
 
 [[LibGit2]]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
@@ -370,32 +360,32 @@ uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 [[Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
+[[MKL_jll]]
+deps = ["Libdl", "Pkg"]
+git-tree-sha1 = "61069ae718b8ab1e325bbfb4e5268902e7ea08e3"
+uuid = "856f044c-d86e-5d09-b602-aeab76dc8ba7"
+version = "2019.0.117+0"
+
 [[MacroTools]]
-deps = ["CSTParser", "Compat", "DataStructures", "Test", "Tokenize"]
-git-tree-sha1 = "d6e9dedb8c92c3465575442da456aec15a89ff76"
+deps = ["DataStructures", "Markdown", "Random"]
+git-tree-sha1 = "e2fc7a55bb2224e203bbd8b59f72b91323233458"
 uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
-version = "0.5.1"
+version = "0.5.3"
 
 [[Markdown]]
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
-[[MatrixFactorizations]]
-deps = ["LinearAlgebra", "Random", "Test"]
-git-tree-sha1 = "95ed2db8197ef7eadce558dff0e9595169672aee"
-uuid = "a3b82374-2e81-5b9e-98ce-41277c0e4c87"
-version = "0.1.0"
-
 [[Measures]]
-deps = ["Test"]
-git-tree-sha1 = "ddfd6d13e330beacdde2c80de27c1c671945e7d9"
+git-tree-sha1 = "e498ddeee6f9fdb4551ce855a46f54dbd900245f"
 uuid = "442fdcdd-2543-5da2-b0f3-8c86c306513e"
-version = "0.3.0"
+version = "0.3.1"
 
 [[Missings]]
-git-tree-sha1 = "29858ce6c8ae629cf2d733bffa329619a1c843d0"
+deps = ["DataAPI"]
+git-tree-sha1 = "de0a5ce9e5289f27df672ffabef4d1e5861247d5"
 uuid = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
-version = "0.4.2"
+version = "0.4.3"
 
 [[Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
@@ -414,21 +404,26 @@ version = "1.5.0"
 
 [[NLSolversBase]]
 deps = ["Calculus", "DiffEqDiffTools", "DiffResults", "Distributed", "ForwardDiff"]
-git-tree-sha1 = "c430bd3f2dfcffc30688cf4a9cb61535e8d85f65"
+git-tree-sha1 = "f1b8ed89fa332f410cfc7c937682eb4d0b361521"
 uuid = "d41bc354-129a-5804-8e4c-c37616107c6c"
-version = "7.4.1"
+version = "7.5.0"
 
 [[NLsolve]]
 deps = ["DiffEqDiffTools", "Distances", "ForwardDiff", "LineSearches", "LinearAlgebra", "NLSolversBase", "Printf", "Reexport"]
-git-tree-sha1 = "c9578878f56f425a2160f5b436c7f79a154d154c"
+git-tree-sha1 = "be25a8486c7be4b075165315e201fa5d199073f1"
 uuid = "2774e3e8-f4cf-5e23-947b-6d7e65073b56"
-version = "4.1.0"
+version = "4.2.0"
 
 [[NaNMath]]
-deps = ["Compat"]
-git-tree-sha1 = "ce3b85e484a5d4c71dd5316215069311135fa9f2"
+git-tree-sha1 = "928b8ca9b2791081dc71a51c55347c27c618760f"
 uuid = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
-version = "0.3.2"
+version = "0.3.3"
+
+[[OpenSpecFun_jll]]
+deps = ["Libdl", "Pkg"]
+git-tree-sha1 = "65f672edebf3f4e613ddf37db9dcbd7a407e5e90"
+uuid = "efe28fd5-8261-553b-a9e1-b2916fc3738e"
+version = "0.5.3+1"
 
 [[OrderedCollections]]
 deps = ["Random", "Serialization", "Test"]
@@ -437,10 +432,10 @@ uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 version = "1.1.0"
 
 [[OrdinaryDiffEq]]
-deps = ["ArrayInterface", "DataStructures", "DiffEqBase", "DiffEqDiffTools", "ExponentialUtilities", "ForwardDiff", "GenericSVD", "LinearAlgebra", "Logging", "MacroTools", "MuladdMacro", "NLsolve", "Parameters", "RecursiveArrayTools", "Reexport", "SparseArrays", "SparseDiffTools", "StaticArrays"]
-git-tree-sha1 = "4b5e5492b95e8c942bf27f64287be6c60e6ab679"
+deps = ["ArrayInterface", "DataStructures", "DiffEqBase", "DiffEqDiffTools", "ExponentialUtilities", "ForwardDiff", "GenericSVD", "LinearAlgebra", "Logging", "MacroTools", "MuladdMacro", "Parameters", "RecursiveArrayTools", "Reexport", "SparseArrays", "SparseDiffTools", "StaticArrays"]
+git-tree-sha1 = "d75c2b12afed168d5ebd60170ebbf46746beac77"
 uuid = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
-version = "5.17.1"
+version = "5.26.4"
 
 [[Parameters]]
 deps = ["OrderedCollections"]
@@ -450,31 +445,31 @@ version = "0.12.0"
 
 [[Parsers]]
 deps = ["Dates", "Test"]
-git-tree-sha1 = "ef0af6c8601db18c282d092ccbd2f01f3f0cd70b"
+git-tree-sha1 = "0139ba59ce9bc680e2925aec5b7db79065d60556"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "0.3.7"
+version = "0.3.10"
 
 [[Pkg]]
-deps = ["Dates", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [[PlotThemes]]
-deps = ["PlotUtils", "Requires", "Test"]
-git-tree-sha1 = "f3afd2d58e1f6ac9be2cea46e4a9083ccc1d990b"
+deps = ["PlotUtils", "Requires", "Statistics"]
+git-tree-sha1 = "df772cc7c78862da96af1ee85cd0111c6640e44e"
 uuid = "ccf2f8ad-2431-5c83-bf29-c5338b663b6a"
-version = "0.3.0"
+version = "1.0.1"
 
 [[PlotUtils]]
-deps = ["Colors", "Dates", "Printf", "Random", "Reexport", "Test"]
-git-tree-sha1 = "8e87bbb778c26f575fbe47fd7a49c7b5ca37c0c6"
+deps = ["Colors", "Dates", "Printf", "Random", "Reexport"]
+git-tree-sha1 = "7622cbde3200a9876a14ba85d66f25d7f4e7a6ca"
 uuid = "995b91a9-d308-5afd-9ec6-746e21dbc043"
-version = "0.5.8"
+version = "0.6.1"
 
 [[Plots]]
 deps = ["Base64", "Contour", "Dates", "FFMPEG", "FixedPointNumbers", "GR", "GeometryTypes", "JSON", "LinearAlgebra", "Measures", "NaNMath", "Pkg", "PlotThemes", "PlotUtils", "Printf", "REPL", "Random", "RecipesBase", "Reexport", "Requires", "Showoff", "SparseArrays", "Statistics", "StatsBase", "UUIDs"]
-git-tree-sha1 = "59bcea95a16912abb229209c9f6e9e218df44b7c"
+git-tree-sha1 = "e71acd7679027efb9b4d0a3f65167302d2722a47"
 uuid = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
-version = "0.26.3"
+version = "0.28.3"
 
 [[PoissonRandom]]
 deps = ["Random", "Statistics", "Test"]
@@ -486,15 +481,11 @@ version = "0.4.0"
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
-[[Profile]]
-deps = ["Printf"]
-uuid = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
-
 [[ProgressMeter]]
 deps = ["Distributed", "Printf"]
-git-tree-sha1 = "fab12b19f198dd148ca467ac4e4f12ecd0241819"
+git-tree-sha1 = "ea1f4fa0ff5e8b771bf130d87af5b7ef400760bd"
 uuid = "92933f4c-e287-5a05-a399-4b506db050ca"
-version = "1.1.0"
+version = "1.2.0"
 
 [[REPL]]
 deps = ["InteractiveUtils", "Markdown", "Sockets"]
@@ -517,9 +508,9 @@ version = "0.7.0"
 
 [[RecursiveArrayTools]]
 deps = ["ArrayInterface", "RecipesBase", "Requires", "StaticArrays", "Statistics"]
-git-tree-sha1 = "ca98c030a187586521fb72d396e14482365ef77f"
+git-tree-sha1 = "cb0fcf68e2e19e76b84c892b22887f02f10f3d9a"
 uuid = "731186ca-8d62-57ce-b412-fbd966d074cd"
-version = "1.0.2"
+version = "1.2.0"
 
 [[RecursiveFactorization]]
 deps = ["LinearAlgebra"]
@@ -540,16 +531,16 @@ uuid = "ae029012-a4dd-5104-9daa-d747884805df"
 version = "0.5.2"
 
 [[ResettableStacks]]
-deps = ["Random", "StaticArrays", "Test"]
-git-tree-sha1 = "8b4f6cf3c97530e1ba7177ad3bc2b134373da851"
+deps = ["StaticArrays"]
+git-tree-sha1 = "d19e9c93de6020a96dbb2820567c78d0ab8f7248"
 uuid = "ae5879a3-cd67-5da8-be7f-38c6eb64a37b"
-version = "0.6.0"
+version = "1.0.0"
 
 [[Roots]]
 deps = ["Printf"]
-git-tree-sha1 = "9cc4b586c71f9aea25312b94be8c195f119b0ec3"
+git-tree-sha1 = "dcc013908465ca1019b34b4bf547b6a187d195f9"
 uuid = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
-version = "0.8.3"
+version = "0.8.4"
 
 [[SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
@@ -587,22 +578,22 @@ deps = ["LinearAlgebra", "Random"]
 uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [[SparseDiffTools]]
-deps = ["Adapt", "ArrayInterface", "BandedMatrices", "BlockBandedMatrices", "DataStructures", "DiffEqDiffTools", "ForwardDiff", "LightGraphs", "LinearAlgebra", "Requires", "SparseArrays", "VertexSafeGraphs"]
-git-tree-sha1 = "c1c5fee07ff2d640aa132c777e89d0fdd6c9e777"
+deps = ["Adapt", "ArrayInterface", "Compat", "DataStructures", "DiffEqDiffTools", "ForwardDiff", "InteractiveUtils", "LightGraphs", "LinearAlgebra", "Requires", "SparseArrays", "VertexSafeGraphs"]
+git-tree-sha1 = "cd6b8c596d97d773fe8ab3b356f252cdc9f6bc37"
 uuid = "47a9eef4-7e08-11e9-0b38-333d64bd3804"
-version = "0.9.1"
+version = "1.1.0"
 
 [[SpecialFunctions]]
-deps = ["BinDeps", "BinaryProvider", "Libdl"]
-git-tree-sha1 = "3bdd374b6fd78faf0119b8c5d538788dbf910c6e"
+deps = ["OpenSpecFun_jll"]
+git-tree-sha1 = "268052ee908b2c086cc0011f528694f02f3e2408"
 uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
-version = "0.8.0"
+version = "0.9.0"
 
 [[StaticArrays]]
 deps = ["LinearAlgebra", "Random", "Statistics"]
-git-tree-sha1 = "db23bbf50064c582b6f2b9b043c8e7e98ea8c0c6"
+git-tree-sha1 = "5a3bcb6233adabde68ebc97be66e95dcb787424c"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "0.11.0"
+version = "0.12.1"
 
 [[Statistics]]
 deps = ["LinearAlgebra", "SparseArrays"]
@@ -622,9 +613,9 @@ version = "1.5.0"
 
 [[StochasticDiffEq]]
 deps = ["ArrayInterface", "DataStructures", "DiffEqBase", "DiffEqDiffTools", "DiffEqNoiseProcess", "FillArrays", "ForwardDiff", "LinearAlgebra", "Logging", "MuladdMacro", "NLsolve", "Parameters", "Random", "RandomNumbers", "RecursiveArrayTools", "Reexport", "SparseArrays", "SparseDiffTools", "StaticArrays"]
-git-tree-sha1 = "5c88268c5fc5d187d542ab07bd1a8966d1b4687b"
+git-tree-sha1 = "1fda79b9919ae2310e969c4000784858abf32f45"
 uuid = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
-version = "6.11.2"
+version = "6.15.0"
 
 [[SuiteSparse]]
 deps = ["Libdl", "LinearAlgebra", "Serialization", "SparseArrays"]
@@ -632,9 +623,9 @@ uuid = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
 
 [[Sundials]]
 deps = ["BinaryProvider", "DataStructures", "DiffEqBase", "Libdl", "LinearAlgebra", "Logging", "Reexport", "SparseArrays", "SuiteSparse"]
-git-tree-sha1 = "e137390db0377d3b9ccd9d019b0c26da0631d8d5"
+git-tree-sha1 = "a4d1e71b4fcfe655e0f96e935d173d1cefeaacc7"
 uuid = "c3572dad-4567-51f8-b174-8c6c989267f4"
-version = "3.7.0"
+version = "3.8.1"
 
 [[TableTraits]]
 deps = ["IteratorInterfaceExtensions"]
@@ -645,11 +636,6 @@ version = "1.0.0"
 [[Test]]
 deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
-[[Tokenize]]
-git-tree-sha1 = "dfcdbbfb2d0370716c815cbd6f8a364efb6f42cf"
-uuid = "0796e94c-ce3b-5d07-9a54-7f471281c624"
-version = "0.5.6"
 
 [[TranscodingStreams]]
 deps = ["Random", "Test"]
@@ -663,12 +649,6 @@ git-tree-sha1 = "8d0d7a3fe2f30d6a7f833a5f19f7c7a5b396eae6"
 uuid = "a2a6695c-b41b-5b7d-aed9-dbfdeacea5d7"
 version = "0.3.0"
 
-[[URIParser]]
-deps = ["Test", "Unicode"]
-git-tree-sha1 = "6ddf8244220dfda2f17539fa8c9de20d6c575b69"
-uuid = "30578b45-9adc-5946-b283-645ec420af67"
-version = "0.4.0"
-
 [[UUIDs]]
 deps = ["Random", "SHA"]
 uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
@@ -676,14 +656,14 @@ uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 [[Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
-[[VersionParsing]]
-deps = ["Compat"]
-git-tree-sha1 = "c9d5aa108588b978bd859554660c8a5c4f2f7669"
-uuid = "81def892-9a0e-5fdd-b105-ffc91e053289"
-version = "1.1.3"
-
 [[VertexSafeGraphs]]
 deps = ["LightGraphs"]
 git-tree-sha1 = "08137053c117afb92f59497160ac2d12abec66d8"
 uuid = "19fa3120-7c27-5ec5-8db8-b0b0aa330d6f"
 version = "0.1.0"
+
+[[ZygoteRules]]
+deps = ["MacroTools"]
+git-tree-sha1 = "b3b4882cc9accf6731a08cc39543fbc6b669dca8"
+uuid = "700de1a5-db45-46bc-99cf-38207098b444"
+version = "0.2.0"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,15 @@ Simple GPE solver using FFTW
 ]add https://github.com/AshtonSBradley/FourierGPE.jl.git
 using FourierGPE
 ```
+## Enabling MKL
+```julia
+using Pkg;
+ENV["JULIA_FFTW_PROVIDER"]="MKL"
+Pkg.build("FFTW")
+```
+Note that MKL for FFTW is provided independently of the package [MKL.jl](https://github.com/JuliaComputing/MKL.jl).
 
+## Getting started
 To get started see runnable examples in the `/examples` directory, or for more information see [FGPEexamples.jl](https://github.com/AshtonSBradley/FGPEexamples.jl)
 
 <img src="https://github.com/AshtonSBradley/FGPEexamples.jl/blob/master/media/3dquenchslab.gif" width="900">

--- a/examples/1dBogoliubov.jl
+++ b/examples/1dBogoliubov.jl
@@ -1,9 +1,7 @@
 using Plots, LaTeXStrings, Pkg, Revise
 gr(size=(600,300),colorbar=false,legend=false,grid=false)
-c1 =:mediumseagreen
 
 using FourierGPE
-
 
 L = (60.0,)
 N = (512,)
@@ -50,7 +48,7 @@ y = abs2.(xspace(sol[end-1],sim)); plot(x,y)
 anim = @animate for i=1:Nt
     ψ = xspace(sol[i],sim)
     y = g*abs2.(ψ)
-    plot(x,y,c=c1,fill=(0,0.3,c1))
+    plot(x,y,c=c3,fill=(0,0.5,c3))
     plot!(x,one.(x)*μ,c=:black,alpha=0.3)
     ylims!(0,1.1)
     xlims!(first(x),last(x))

--- a/examples/1d_temporal_soliton.jl
+++ b/examples/1d_temporal_soliton.jl
@@ -3,7 +3,6 @@ gr(colorbar=false,size=(600,150),legend=false,grid=false)
 
 using FourierGPE
 
-
 #--- Initialize simulation
 L = (40.0,)
 N = (2048,)
@@ -36,7 +35,7 @@ sol = runsim(sim)
 #--- plot
 plot(x,abs2.(ψi),lw=3,c=:red)
 y = abs2.(xspace(sol[Nt],sim))
-plot!(x,y,lw=3,c=c1,fill=(0, 0.4,c1))
+plot!(x,y,lw=3,c=c3,fill=(0, 0.4,c3))
 xlims!(-5,5)
 
 #--- animate
@@ -44,7 +43,7 @@ anim = @animate for i=1:Nt
     ψ = xspace(sol[i],sim)
     y = abs2.(ψ)
     # plot(x,abs2.(ψi),lw=3,c=:red,alpha=0.4)
-    plot(x,y,c=c1,fill=(0, 0.4,c1),size=(400,300),xticks=false,yticks=false,axis=false)
+    plot(x,y,c=c3,fill=(0, 0.4,c3),size=(400,300),xticks=false,yticks=false,axis=false)
     xlims!(-2.2,2.2)
     ylims!(0,220)
 end

--- a/examples/1dbrightsoliton.jl
+++ b/examples/1dbrightsoliton.jl
@@ -1,6 +1,5 @@
 using Plots, LaTeXStrings, Pkg, Revise
 gr(colorbar=false,size=(600,150),legend=false,grid=false,xticks=false,yticks=false,axis=false)
-c1 =:mediumseagreen
 
 using FourierGPE
 
@@ -43,7 +42,7 @@ plot(x,y,fill=(0, 0.2))
 anim = @animate for i=1:Nt-8
     ψ = xspace(sol[i],sim)
     y = abs2.(ψ)
-    plot(x,y,c=c1,fill=(0, 0.4,c1))
+    plot(x,y,c=c3,fill=(0, 0.4,c3))
 end
 
 gif(anim, "./examples/brightsoliton.gif", fps = 25)

--- a/examples/1dharmonicDarkSoliton.jl
+++ b/examples/1dharmonicDarkSoliton.jl
@@ -1,6 +1,5 @@
 using Plots, LaTeXStrings, Pkg, Revise
 gr(grid=false,legend=false,titlefontsize=12,size=(500,300),transpose=true,colorbar=false)
-c1 =:mediumseagreen
 
 using FourierGPE
 
@@ -32,7 +31,7 @@ sol = runsim(sim)
 ψg = xspace(ϕg,sim)
 plot(x,one.(x)*μ,ls=:solid,c=:gray,w=1)
 plot!(x,V.(x,0.0),c=:red,w=4,alpha=0.4)
-plot!(x,g*abs2.(ψg),c=c1,w=2,fill=(0,0.4,c1),size=(600,200))
+plot!(x,g*abs2.(ψg),c=c3,w=2,fill=(0,0.4,c3),size=(600,200))
 xlims!(-10,10); ylims!(0,1.3*μ)
 title!(L"\textrm{local}\; \mu(x)")
 xlabel!(L"x/a_x"); ylabel!(L"\mu(x)/\hbar\omega_x")
@@ -70,7 +69,7 @@ showpsi(x,ψf)
 anim = @animate for i in 1:length(t)-3
     ψ = xspace(sols[i],simSoliton)
     y = g*abs2.(ψ)
-    plot(x,y,c=c1,w=2,fill=(0,0.4,c1),size=(600,300),grid=false)
+    plot(x,y,c=c3,w=2,fill=(0,0.4,c3),size=(600,300),grid=false)
     xlims!(-10,10); ylims!(0,1.3*μ)
     title!(L"\textrm{local}\; \mu(x)")
     xlabel!(L"x/a_x"); ylabel!(L"\mu(x)/\hbar\omega_x")

--- a/examples/2dBogoliubov.jl
+++ b/examples/2dBogoliubov.jl
@@ -1,5 +1,7 @@
-using Plots, LaTeXStrings, Pkg, Revise, FourierGPE
+using Plots, LaTeXStrings, Pkg, Revise
 gr(colorbar=false,size=(300,300),legend=false,grid=false)
+
+using FourierGPE
 
 #--- setup
 L = (60.0,60.)

--- a/examples/2ddipole.jl
+++ b/examples/2ddipole.jl
@@ -1,10 +1,8 @@
 #--- load packages
-using Test, Plots, LaTeXStrings, Revise, FourierGPE, VortexDistributions
+using Test, Plots, LaTeXStrings, VortexDistributions
 gr(titlefontsize=12,size=(500,300),transpose=true,colorbar=false)
 
-using ColorSchemes
-c1 = cgrad(ColorSchemes.linear_blue_5_95_c73_n256.colors)
-c2 = cgrad(ColorSchemes.turbo.colors)
+
 import FourierGPE:showpsi
 
 function showpsi(x,y,ψ)

--- a/examples/2ddipole_spectra.jl
+++ b/examples/2ddipole_spectra.jl
@@ -1,5 +1,7 @@
-using Test, Plots, LaTeXStrings, Revise, FourierGPE, VortexDistributions
+using Test, Plots, LaTeXStrings, VortexDistributions
 gr(titlefontsize=12,size=(500,300),transpose=true,colorbar=false)
+
+using FourierGPE
 
 function psimovie(sol,sim)
     @unpack X,t = sim; x,y = X
@@ -54,6 +56,7 @@ showpsi(x,y,ψg)
 ψv = copy(ψg)
 d = 30
 ξv = healinglength(0.,0.,μ,g)
+
 # can use default ξ = 1
 pv = PointVortex(0.,d/2,1)
 nv = PointVortex(0,-d/2,-1)

--- a/examples/2dexpansion.jl
+++ b/examples/2dexpansion.jl
@@ -1,6 +1,7 @@
-using FourierGPE
+using Plots
 gr(titlefontsize=12,size=(500,300),transpose=true,colorbar=false)
 
+using FourierGPE
 # Units
 # this example works in oscillator units
 

--- a/examples/2dvortexprecession.jl
+++ b/examples/2dvortexprecession.jl
@@ -1,4 +1,6 @@
-using Plots, FourierGPE
+using Plots
+
+using FourierGPE
 #--- Initialize simulation
 L = (18.0,18.0)
 N = (128,128)

--- a/examples/3dKohn.jl
+++ b/examples/3dKohn.jl
@@ -1,5 +1,8 @@
-using Pkg, Revise, FourierGPE
+using Plots
 gr(titlefontsize=12,size=(500,300),colorbar=false)
+
+using Pkg;Pkg.activate(".")
+using FourierGPE
 
 # Units: Oscillator
 L = (15.,15.,15.)
@@ -81,7 +84,7 @@ gif(anim,"./examples/3dKohnSurface.mov",fps=30)
 
 simk
 
-#--- animate isosurface in Makie 
+#--- animate isosurface in Makie
 using Makie, AbstractPlotting
 
 function dense(phi)

--- a/examples/3dharmonic.jl
+++ b/examples/3dharmonic.jl
@@ -1,3 +1,5 @@
+
+
 using FourierGPE
 
 # Units: oscillator
@@ -49,7 +51,7 @@ anim = @animate for i=1:Nt
 end
 gif(anim,"./examples/3dquench.gif",fps=30)
 
-#--- animate isosurface in Makie 
+#--- animate isosurface in Makie
 using Makie, AbstractPlotting
 
 function dense(phi)
@@ -65,7 +67,7 @@ function densityfilm(sol,Nt;file="3dquench.gif")
     tindex = Node(1)
     scene = volume(lift(i -> dense(sol[i]), tindex),
     algorithm = :iso,
-    color = (:mediumseagreen,0.25),
+    color = (c3,0.25),
     show_axis=false,
     isovalue=3f0(.15))
 

--- a/examples/3dharmonicThomasFermi.jl
+++ b/examples/3dharmonicThomasFermi.jl
@@ -1,5 +1,6 @@
-using Pkg, Revise
+using Plots
 gr(titlefontsize=12,size=(500,300),colorbar=false)
+
 
 using FourierGPE
 
@@ -37,7 +38,6 @@ plot!(x,abs2.(ψi[:,32,32]))
 #--- evolve in k space
 sol = runsim(sim)
 
-
 #--- ground state
 ϕg = sol[end]
 ψg = xspace(ϕg,sim)
@@ -57,12 +57,12 @@ abs2.(ψg[32,32,32])
 anim = @animate for i=1:Nt
     ϕ = sol[i]
     zmid = findfirst(z .≈ 0)
-    ψ = xspace(ϕ,sim)[:,:,zmid]
-    showpsi(x,y,ψ)
+    ψ = xspace(ϕ,sim)
+    showpsi(x,y,ψ[:,:,zmid])
 end
 gif(anim,"./examples/3dquench.gif",fps=30)
-
-#--- animate isosurface in Makie 
+#TODO debug
+#--- animate isosurface in Makie
 using Makie, AbstractPlotting
 
 function dense(phi)
@@ -78,7 +78,7 @@ function densityfilm(sol,Nt;file="3dquench.gif")
     tindex = Node(1)
     scene = volume(lift(i -> dense(sol[i]), tindex),
     algorithm = :iso,
-    color = (:mediumseagreen,0.25),
+    color = (c3,0.25),
     show_axis=false,
     isovalue=3f0(.15))
 

--- a/src/FourierGPE.jl
+++ b/src/FourierGPE.jl
@@ -16,6 +16,7 @@ using Reexport
 
 const c1 = cgrad(ColorSchemes.inferno.colors)
 const c2 = cgrad(ColorSchemes.RdBu_11.colors)
+const c3 =:mediumseagreen
 
 include("types.jl")
 include("arrays.jl")
@@ -31,7 +32,7 @@ export initsim!, runsim, internalnorm
 export Transforms, @pack_Transforms!, @unpack_Transforms
 export Sim, @pack_Sim!, @unpack_Sim, showpsi, testsim
 export Params, @pack_Params!, @unpack_Params
-export k2, @pack!, @unpack, makeT, makeTMixed, definetransforms
-export Field, XField, KField, velocity, energydecomp, helmholtz, c1, c2
+export k2, @pack!, @unpack, makeT, definetransforms #makeTMixed,
+export Field, XField, KField, velocity, energydecomp, helmholtz, c1, c2, c3
 export log10range, zeropad, autocorrelate, convolve, kespectrum, ikespectrum
 end # module

--- a/src/transforms.jl
+++ b/src/transforms.jl
@@ -103,9 +103,9 @@ function makeT(X,K,j=1;flags=FFTW.MEASURE)
 
     # flags != FFTW.MEASURE && @info "Planning FFTs ..."
     Txk,Txk!,Tkx,Tkx! = definetransforms(trans,args,meas,flags)
-    Mxk,Mxk!,Mkx,Mkx! = makeTMixed(X,K,flags=flags)
+    # Mxk,Mxk!,Mkx,Mkx! = makeTMixed(X,K,flags=flags)
     # @info "...Plans created."
-    return Transforms{dim,j}(Txk,Txk!,Tkx,Tkx!,Mxk,Mxk!,Mkx,Mkx!,crandnpartition(dim,j))
+    return Transforms{dim,j}(Txk,Txk!,Tkx,Tkx!,crandnpartition(dim,j))
 end
 
 """

--- a/src/types.jl
+++ b/src/types.jl
@@ -23,10 +23,6 @@ end
     Txk!::AbstractFFTs.ScaledPlan{Complex{Float64},FFTW.cFFTWPlan{Complex{Float64},-1,true,D},Float64} = 0.1*plan_fft!(crandn_array(D))
     Tkx::AbstractFFTs.ScaledPlan{Complex{Float64},FFTW.cFFTWPlan{Complex{Float64},1,false,D},Float64} = 0.1*plan_ifft(crandn_array(D))
     Tkx!::AbstractFFTs.ScaledPlan{Complex{Float64},FFTW.cFFTWPlan{Complex{Float64},1,true,D},Float64} = 0.1*plan_ifft!(crandn_array(D))
-    Mxk::Array{AbstractFFTs.ScaledPlan{Complex{Float64},FFTW.cFFTWPlan{Complex{Float64},-1,false,D},Float64},1} = makeTMixed(D)[1]
-    Mxk!::Array{AbstractFFTs.ScaledPlan{Complex{Float64},FFTW.cFFTWPlan{Complex{Float64},-1,true,D},Float64},1} = makeTMixed(D)[2]
-    Mkx::Array{AbstractFFTs.ScaledPlan{Complex{Float64},FFTW.cFFTWPlan{Complex{Float64},1,false,D},Float64},1} = makeTMixed(D)[3]
-    Mkx!::Array{AbstractFFTs.ScaledPlan{Complex{Float64},FFTW.cFFTWPlan{Complex{Float64},1,true,D},Float64},1} = makeTMixed(D)[4]
     psi::ArrayPartition = crandnpartition(D,N)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,6 @@
 using FourierGPE, Test
 
 @testset "Parseval test" begin include("test_parseval.jl") end
-@testset "Mixed Parseval" begin include("test_mixedparseval.jl") end
 @testset "Ground state" begin include("test_groundstate.jl") end
 @testset "Dynamics" begin include("test_dynamics.jl") end
 @testset "Analysis" begin include("test_analysis.jl") end

--- a/test/test_MKL.jl
+++ b/test/test_MKL.jl
@@ -1,4 +1,6 @@
 # Test MKL plans
+using Pkg
+Pkg.activate(".")
 using FourierGPE, Test
 
 #transform tests

--- a/test/test_MKL_3d.jl
+++ b/test/test_MKL_3d.jl
@@ -1,0 +1,344 @@
+#================================#
+#=== 3D expansion simulations ===#
+#================================#
+using Pkg
+Pkg.activate(".")
+using FourierGPE, Test
+
+
+#--- density with Makie
+using Makie, AbstractPlotting
+function dense(phi)
+    ψm = xspace(phi,sim)
+    density = abs2.(ψm)
+    pmax = maximum(density)
+    return density/pmax
+end
+
+function densityfilm(sol,Nt;file="3dquenchtrap.gif")
+    dir = "media"
+    !isdir(dir) && mkdir(dir)
+    saveto=joinpath("media",file)
+
+    scene = Scene()
+    tindex = Makie.Node(1)
+    scene = volume(lift(i -> dense(sol[i]), tindex),
+    algorithm = :iso,
+    color = (:mediumseagreen,0.15),
+    show_axis=false,
+    isovalue=3f0(.15))
+
+    R = 70
+    eyeat = Vec3f0(R,R,R)
+    lookat = Vec3f0(0,0,0)
+
+    record(scene, saveto, 1:Nt) do i
+        update_cam!(scene, eyeat, lookat)
+        rotate_cam!(scene, 0., -0.1, 0.)
+        tindex[] = i
+    end
+    p = scene[end];
+    return
+end
+
+#==================================#
+
+#--- 3D expansion
+using Plots, Interact, LaTeXStrings, FourierGPE
+gr(titlefontsize=12,size=(500,300),transpose=true,colorbar=false)
+
+#--- Scaling GPE
+import FourierGPE: nlin!, Lgp!
+
+function k2_scaling(K,λ,t)
+    Ks = K./λ(t)
+    k2(Ks)
+end
+
+#TODO we need to learn a bit about iterators, do, map
+
+# const yt = y'
+# const zt = reshape(z,1,1,length(z))
+
+function nlin!(dϕ,ϕ,sim::Sim{3},t)
+    @unpack g,X,V0 = sim; x,y,z = X
+    yt = y'
+    zt = reshape(z,1,1,length(z))
+    dϕ .= ϕ
+    xspace!(dϕ,sim)
+    @. dϕ *= V0 + g*abs2(dϕ)/λx(t)/λy(t)/λz(t) + V(λx(t)*x,λy(t)*yt,λz(t)*zt,t)
+    kspace!(dϕ,sim)
+end
+
+function Lgp!(dϕ,ϕ,sim::Sim{3},t)
+    @unpack γ,μ,espec,K = sim
+    nlin!(dϕ,ϕ,sim,t)
+    espec = 0.5*k2_scaling(K,λ,t)
+    @. dϕ = -im*(1.0 - im*γ)*(dϕ + (espec - μ)*ϕ)
+end
+
+function r2_scaling(X,λ,λ̇,t)
+    @assert eltype(sqrt.(λ(t).*λ̇(t))) <: Real
+    rs = X.*sqrt.(λ(t).*λ̇(t))
+    ρs = Iterators.product(rs...)
+    map(x->sum(abs2.(x)),ρs)
+end
+
+function remove_phase!(ψ,t)
+    ψ .*= exp.(-im*r2_scaling(X,λ,λ̇,t)/2)
+end
+
+function restore_phase!(ψ,t)
+    ψ .*= exp.(im*r2_scaling(X,λ,λ̇,t)/2)
+end
+
+init_phase!(ψ) = remove_phase!(ψ,0)
+
+#--- First, we verify Castin-Dum scaling inversion
+# using parameters of Mewes et al 1996 (or smaller N)
+
+# initialize default sim
+L = (50,50,3)
+N = (32,32,32)
+sim = Sim(L,N)
+@unpack_Sim sim;
+
+# convenient units
+mum = 1e-6
+nm = 1e-9
+amu = 1.661e-27
+ħ = 1.055e-34
+a0 = 0.05nm
+
+# Rb87 parameters
+m = 87amu
+as = 5.8nm
+
+# simulation params in units of wr, ar
+wr = 18*2pi
+wz = 320*2pi
+az = sqrt(ħ/m/wz)
+ar = sqrt(ħ/m/wr)
+gdim = 4*pi*ħ^2*as/m
+g = gdim/(ħ*wr)/ar^3
+
+
+ar = 1.
+az = wr/wz |> sqrt
+wz /= wr
+wr = 1.
+
+γ = 0.1
+μ = 50.0
+Rr_tf = sqrt(2*μ)
+Rz_tf = sqrt(2*μ/wz^2)
+
+# make grids
+X,K,dX,dK = makearrays(L,N)
+x,y,z = X
+yt = y'
+zt = reshape(z,1,1,length(z))
+
+# time info
+tf = .2/γ
+Nt = 100
+t = LinRange(0.,tf,Nt)
+
+# potential for initial state (prolate)
+import FourierGPE:V
+V(x,y,z,t) = 0.5*(x^2 + y^2 + wz^2*z^2)
+λx(t) = 1.
+λy(t) = 1.
+λz(t) = 1.
+
+λẋ(t) = 0.
+λẏ(t) = 0.
+λż(t) = 0.
+
+λ(t) = (λx(t),λy(t),λz(t))
+λ̇(t) = (λẋ(t),λẏ(t),λż(t))
+
+# random initial state
+# ψi = randn(N)+im*randn(N)
+
+#Thomas-Fermi initial state
+zmid = N[3]/2 |> Int
+ψ0(x,y,z,μ,g) = sqrt(μ/g)*sqrt(max(1.0-V(x,y,z,0.0)/μ,0.0)+im*0.0)
+ψi = ψ0.(x,yt,zt,μ,g)
+showpsi(x,y,ψi[:,:,zmid])
+
+ϕi = kspace(ψi,sim)
+
+# check atom number
+Na = sum(abs2.(ψi))*prod(dX)
+
+#save files?
+nfiles = true
+path = joinpath(@__DIR__,"oblate_ground_state")
+
+#--- Evolve in k space
+@pack_Sim! sim
+@time sol = runsim(sim)
+
+#--- slice through z=0:
+ϕg = sol[end]
+
+# loadfile = joinpath(path,"save200.jld2")
+# @load loadfile ψ
+# ϕg = ψ
+ψg = xspace(ϕg,sim)
+showpsi(x,y,ψg[:,:,zmid])
+
+#--- one D plot
+Vplot(x,y,z,t) = 0.5*(x^2 + y^2 + wz^2*z^2)
+ψtfplot(x,y,z,μ,g)=sqrt(μ/g)*sqrt(max(1.0-Vplot(x,y,z,0.0)/μ,0.0)+im*0.0)
+Plots.plot(x,g*abs2.(ψi[:,16,16]),label=L"|\psi(x)|^2")
+Plots.plot!(x,g*abs2.(ψtfplot.(x,0,0,μ,g)),label=L"n_{TF}(x)")
+
+#--- file for easy load
+function loadpsi(i::Int,sim)
+    padi = lpad(string(i),ndigits(length(sim.t)),"0")
+    fromfile = joinpath(sim.path,sim.filename*padi*".jld2")
+    ϕt = load(fromfile,"ψ")
+end
+
+
+#--- initial state for expansion
+# tind = 200
+# ϕt = sol[tind]
+# ψt = xspace(ϕt,sim)
+
+tind = 100
+ϕt = loadpsi(tind,sim)
+ψt = xspace(ϕt,sim)
+
+@manipulate for i in 1:zmid
+    showpsi(x,y,ψt[:,:,i])
+end
+
+#--- save initial state
+# using JLD2, FileIO
+
+tofile = "initial_state_oblate.jld2"
+save(tofile,"ϕt",ϕt)
+
+#--- Free expansion
+fromfile = tofile
+load(fromfile,"ϕt")
+
+#save files?
+nfiles = true
+path = joinpath(@__DIR__,"oblate_expansion")
+
+# potential
+V(x,y,z,t) = 0.0
+
+# Scaling GPE: free expansion scaling law (Castin-Dum)
+λx(t) = sqrt(1+(wr*t)^2)
+λy(t) = sqrt(1+(wr*t)^2)
+λz(t) = sqrt(1+(wz*t)^2)
+
+λẋ(t) = wr^2*t/λx(t)
+λẏ(t) = wr^2*t/λy(t)
+λż(t) = wz^2*t/λz(t)
+
+λ(t) = (λx(t),λy(t),λz(t))
+λ̇(t) = (λẋ(t),λẏ(t),λż(t))
+
+# Parameters
+γ = 0.0
+ti = 0.0
+tf = 10
+Nt = 200
+t = LinRange(ti,tf,Nt)
+ϕi .= ϕt
+
+ψi .= xspace(ϕi,sim)
+init_phase!(ψi)
+ϕi .= kspace(ψi,sim)
+
+simes = Sim(L,N)
+@pack_Sim! simes
+
+simes
+#--- Evolve
+@time soles = runsim(simes)
+
+#--- Plot
+@manipulate for i in 1:zmid, tind in 1:length(t)
+    ϕf = loadpsi(tind,simes)
+    ψf = xspace(ϕf,simes)
+    s = t[tind]
+    # showpsi(x*λx(s),y*λy(s),ψf[:,:,i])
+    # showpsi(x*λy(s),y*λz(s),ψf[i,:,:])
+    p1 = Plots.heatmap(y*λy(s),z*λz(s),abs2.(ψf[i,:,:]),c=:inferno,colorbar=true)
+    Plots.xlabel!(L"y/a_z")
+    Plots.ylabel!(L"z/a_z")
+end
+
+#--- aspect ratio
+aspect = zero.(t)
+
+x = X[1]
+z = X[3]
+
+for i in eachindex(t)
+    ϕf = loadpsi(i,simes)
+    ψf = xspace(ϕf,simes)
+    s = t[i]
+    zt = reshape(z,1,1,length(z))
+    sx = sum(abs2.(ψf).*x.^2) |> sqrt
+    sz = sum(abs2.(ψf).*zt.^2) |> sqrt
+    aspect[i] = (λz(s)/λx(s))*sz/sx
+end
+
+# aspect_tinf = 2/π/ϵ
+# aspect_analytic(t) = (Rr_tf/Rz_tf)*λx(t)/λz(t)
+
+p1 = Plots.plot(t,aspect,size=(500,250),legend=:bottomright,label="sGPE")
+# Plots.plot!(t,aspect_analytic.(t),c=:red,label="Castin-Dum")
+# Plots.ylims!(1e-1,1e1)
+# Plots.plot!(t,one.(t)*aspect_tinf,ls=:dash,label=L"2\omega_\perp/(\pi\omega_z)")
+Plots.xlabel!(L"\omega_z t")
+Plots.ylabel!(L"R_z(t)/R_\perp(t)")
+
+# <x^2>/<z^2> and Rx^2/Rz^2 are equivalent for Thomas-Fermi approximation
+
+# savefig(p1,"expand_oblate_comparison.pdf")
+#--- make movie
+# @time p = densityfilm(soles,Nt,file="3dfree_expansion.gif")
+
+#--- plot column density
+@manipulate for i in 1:4:lastindex(t)
+    ϕf = soles[i]
+    ψf = xspace(ϕf,simes)
+    ψcd = dropdims(sum(ψf,dims=3),dims=3)
+    s = t[i]
+    showpsi(x*λ(s),y*λ(s),ψcd/λ(s))
+end
+
+#--- compute aspect ratio from standard deviations in r,z
+dx = diff(x)[1]; dy = diff(y)[1];dz = diff(z)[1]
+Na(ψ) = sum(abs2.(ψ))*dx*dy*dz
+Rz(ψ) = sum(abs2.(ψ).*zt.^2)*dx*dy*dz/Na(ψ) |> abs |> sqrt
+Rr(ψ) = sum(abs2.(ψ).*(x.^2 .+ yt.^2))*dx*dy*dz/Na(ψ) |> abs |> sqrt
+aspect_ratio(ψ) = Rr(ψ)/Rz(ψ)
+
+α0 = aspect_ratio(xspace(soles[1],simes))
+α = zero(t)
+
+for j in eachindex(t)
+    α[j] = aspect_ratio(xspace(soles[j],simes))
+end
+
+plot(t,α,legend=false)
+ylims!(0,3.2)
+plot!(t,one.(t)*2/α0/pi,ls=:dash)
+
+#--- check against TF radii with fitting
+Rz_tf0 = sqrt(2*μ)
+Rperp_tf0 = sqrt(2*μ/64)
+
+a0 = Rperp_tf0/Rz_tf0
+
+2/pi/a0


### PR DESCRIPTION
MKL seems to dislike mixed transforms. Here we remover them with the intention that they can be restored at a later date when time allows. 

MKL is significant enough to prioritize here. 

Factors of at least 2 in 3D, and more in 1D, 2D appear to be available with MKL. 